### PR TITLE
Refactor export script and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 stores.json
+__pycache__/
+error_log.txt

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This script exports Shopify store data, including Products, Orders, Blogs, and m
 ```
 
 ### **2️⃣ Install Dependencies**
-Ensure you have Python installed. Then, install required dependencies:
+Ensure you have Python installed. Then, install the required dependencies:
 ```sh
-pip install requests pandas beautifulsoup4
+pip install -r requirements.txt
 ```
 
 ![XPORTIFY Banner](https://github.com/CSR2HUB/Shopify-XPOREFY/blob/main/xportefy.png)
@@ -52,7 +52,7 @@ python export_shopify.py
 - Blog articles are stored **individually** per category.
 
 ## 🛑 Error Logging
-Errors are logged in `error_log.txt` for debugging.
+Errors are logged in `error_log.txt` inside the export folder for debugging.
 
 ## 📜 License
 This project is open-source. Feel free to modify and use it.

--- a/export_shopify.py
+++ b/export_shopify.py
@@ -2,11 +2,10 @@ import requests
 import json
 import os
 import pandas as pd
-import psutil
 import time
-import subprocess
 from bs4 import BeautifulSoup
 from datetime import datetime
+import xml.etree.ElementTree as ET
 
 # Shopify API version
 API_VERSION = "2025-01"
@@ -43,13 +42,6 @@ def display_welcome():
     print("🚀 Export & Download – HUB handles everything automatically.\n")
     print("=" * 50)
 
-# Function to save stores
-def save_store(store):
-    stores = load_stores()
-    stores[store["store_url"]] = store  # Save using store URL as key
-    with open(STORE_FILE, "w") as file:
-        json.dump(stores, file, indent=4)
-
 # Function to fetch store details from Shopify API
 def fetch_store_info(api_key, admin_access_token, store_url):
     """Fetch Shopify store details using API key and access token."""
@@ -72,10 +64,6 @@ def fetch_store_info(api_key, admin_access_token, store_url):
     except requests.exceptions.RequestException as e:
         print(f"❌ API request failed: {str(e)}")
         return None, None, None
-
-# 📌 File to save store credentials
-STORE_FILE = "stores.json"
-store_credentials = {}
 
 # Shopify API endpoints
 SHOPIFY_ENDPOINTS = {
@@ -101,7 +89,7 @@ def get_export_folder():
 def log_error(message):
     """Logs errors to a file with a timestamp."""
     folder = get_export_folder()  # Ensure folder is defined dynamically
-    error_log = os.path.join(folder, "error_log.txt")  # Use get_export_folder()
+    error_log = os.path.join(folder, ERROR_LOG_FILE)
     
     with open(error_log, "a") as f:
         f.write(f"{datetime.now()} - {message}\n")
@@ -520,6 +508,7 @@ def migrate_data():
     print(f"📦 Source Store: {store_credentials['store_name']} ({store_credentials['store_url']})\n")
 
 # 🚀 Start the script
-display_welcome()
-setup_store()  # Load or select store
-main_menu()
+if __name__ == "__main__":
+    display_welcome()
+    setup_store()  # Load or select store
+    main_menu()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+pandas
+beautifulsoup4

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,26 @@
+import tempfile
+import json
+import os
+import importlib
+
+import sys
+sys.path.insert(0, str(os.path.dirname(os.path.dirname(__file__))))
+import export_shopify as es
+
+
+def test_save_and_load_store(tmp_path, monkeypatch):
+    test_file = tmp_path / "stores.json"
+    monkeypatch.setattr(es, "STORE_FILE", str(test_file))
+
+    store = {
+        "store_name": "teststore",
+        "store_url": "test.myshopify.com",
+        "api_key": "key",
+        "api_secret_key": "secret",
+        "admin_access_token": "token",
+    }
+
+    es.save_store(store)
+    loaded = es.load_stores()
+    assert store["store_url"] in loaded
+    assert loaded[store["store_url"]]["api_key"] == "key"


### PR DESCRIPTION
## Summary
- clean up unused imports and use ElementTree
- consolidate duplicate constants and functions
- reference error log constant in `log_error`
- add entry point guard
- ignore Python cache and logs
- document requirements in README
- add `requirements.txt`
- add a simple pytest for store functions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434c0b0090832b93a8d5ff2041da95